### PR TITLE
Add unlocalized strings from innerHTML fixes

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -391,5 +391,13 @@
   },
   "filterInputPlaceholder": {
     "message": "Search container name"
+  },
+  "imageAltContainerInfo": {
+    "message": "Container info",
+    "description": "Alt text for right-arrow button to view container info"
+  },
+  "defaultContainerLabel": {
+    "message": "Default Container",
+    "description": "The title of the default container"
   }
 }


### PR DESCRIPTION
When fixing this issue: https://github.com/mozilla/multi-account-containers/pull/2491, I ran across two strings that were unlocalized. 

Preview: 
"Default Container" 

<img width="382" alt="image" src="https://user-images.githubusercontent.com/2692333/218535172-fbc85bb1-01b5-4078-ae05-5c2621132dfb.png">


(The second string was an unlocalized alt tag) 
