### PR TITLE
Rebrand Firefox Account in english locales

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -72,14 +72,14 @@
   "onboarding-6-header": {
     "message": "Syncing Containers is now Available!"
   },
-  "onboarding-6-description": {
-    "message": "Turn on sync to share Container and site assignments with any computer connected to your Firefox account."
+  "onboarding-6-description-2": {
+    "message": "Turn on sync to share Container and site assignments with any computer connected to your account."
   },
-  "onboarding-7-header": {
-    "message": "Firefox account is required to sync."
+  "onboarding-7-header-2": {
+    "message": "An account is required to sync."
   },
-  "onboarding-7-description": {
-    "message": "Click Sign In to confirm that your Firefox account is active."
+  "onboarding-7-description-2": {
+    "message": "Click Sign In to confirm that your account is active."
   },
   "onboarding-8-description": {
     "message": "Now Containers can integrate with Mozilla VPN or your own proxy to create a secure, private connection that protects your activity."
@@ -211,11 +211,11 @@
   "enableBookMarkMenus": {
     "message": "Enable Bookmark Menus"
   },
-  "firefoxAccountsSync": {
-    "message": "Firefox accounts sync:"
+  "sync": {
+    "message": "Synchronization:"
   },
   "enableSync": {
-    "message": "Enable sync"
+    "message": "Enable synchronization"
   },
   "enableBookMarkMenusDescription": {
     "message": "This setting allows you to open a bookmark or folder of bookmarks in a Container."


### PR DESCRIPTION
Change strings containing Firefox Account to use a generic term "account" instead. I modified the 3 english locales and we'd like to land this patch before pushing a new version on AMO so contributors have time to update other locales.