### PR TITLE
Strings for a new confirmation panel for container storage clearing.

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -123,6 +123,12 @@
   "removeThisContainerConfirmation": {
     "message": "Are you sure you want to remove this Container?"
   },
+  "clearContainerStoragePanelTitle": {
+    "message": "Clear Container Storage"
+  },
+  "clearContainerStorageConfirmation": {
+    "message": "Are you sure you want to clear cookies and storage for this Container?"
+  },
   "cancel": {
     "message": "Cancel"
   },


### PR DESCRIPTION
This PR adds a couple strings for the confirmation panel when clearing a containers cookies and storage.

Reference PR: https://github.com/mozilla/multi-account-containers/pull/2654