### PR TITLE
adds the required strings for sort tabs confirmation panel

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -117,6 +117,12 @@
   "showThisContainer": {
     "message": "Show This Container"
   },
+  "sortTabs":{
+    "message" : "sort tabs"
+  },
+  "sortTabsConfirmation": {
+    "message": "Are you sure you want to sort all tabs?"
+  },
   "removeThisContainer": {
     "message": "Remove This Container"
   },


### PR DESCRIPTION
Title: Add English locale strings

Description:
This PR adds the necessary English locale strings to the en/ folder. No other locales were modified. The changes ensure proper localization for the extension.