### PR TITLE
New strings: (currently EN only), accommodating add-on repo PR # 2880: for the list of tabs in all windows title and move tabs from all windows menu item

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -34,10 +34,17 @@
   },
   "openTabs": {
     "message": "Open Tabs",
-    "description": "Section title for tabs that are currently open in that container"
+    "description": "Section title for tabs that are currently open in that container in the current window"
+  },
+  "openTabsInOtherWindows": {
+    "message": "Open Tabs in Other Windows",
+    "description": "Section title for tabs that are currently open in that container in other windows"
   },
   "moveTabsToANewWindow": {
     "message": "Move Tabs to a New Window"
+  },
+  "moveTabsInAllWinsToASingleWindow": {
+    "message": "Move Tabs in All Windows to a Single Window"
   },
   "onboarding-1-header": {
     "message": "A better way to manage all the things you do online"


### PR DESCRIPTION
Two new strings: `Open Tabs in Other Windows` and `Move Tabs in All Windows to a Single Window`.
See https://github.com/mozilla/multi-account-containers/pull/2880.

Only English strings are added.