### PR TITLE
Feature PR #2912: catchall domains - new strings (English only)

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -135,6 +135,10 @@
   "ok": {
     "message": "OK"
   },
+  "enableAllSubdomains": {
+    "message": "Enable all subdomains from these domains",
+    "description": "Header for catchall domains section of sites-assigned panel"
+  },
   "sitesAssignedToThisContainer": {
     "message": "Sites assigned to this Container"
   },

--- a/en_CA/messages.json
+++ b/en_CA/messages.json
@@ -135,6 +135,10 @@
   "ok": {
     "message": "OK"
   },
+  "enableAllSubdomains": {
+    "message": "Enable all subdomains from these domains",
+    "description": "Header for catchall domains section of sites-assigned panel"
+  },
   "sitesAssignedToThisContainer": {
     "message": "Sites assigned to this Container"
   },

--- a/en_GB/messages.json
+++ b/en_GB/messages.json
@@ -135,6 +135,10 @@
   "ok": {
     "message": "OK"
   },
+  "enableAllSubdomains": {
+    "message": "Enable all subdomains from these domains",
+    "description": "Header for catchall domains section of sites-assigned panel"
+  },
   "sitesAssignedToThisContainer": {
     "message": "Sites assigned to this Container"
   },


### PR DESCRIPTION
https://github.com/mozilla/multi-account-containers/pull/2912

Adds English strings required by catchall domains feature:

<img width="423" height="655" alt="mac-domains" src="https://github.com/user-attachments/assets/65d8b4d3-d94c-4cc8-aab8-599d08bde513" />
