### PR TITLE
Add strings for alphabetical container sort

### DIFF
--- a/en/messages.json
+++ b/en/messages.json
@@ -238,6 +238,15 @@
   "syncExcludeDescription": {
     "message": "Exclude containers from sync when their name matches the specified case insensitive regular expression."
   },
+  "containerList": {
+    "message": "Container list:"
+  },
+  "alphabeticalSort": {
+    "message": "Sort containers alphabetically"
+  },
+  "alphabeticalSortDescription": {
+    "message": "Keep the container list sorted by name. New, renamed and synced containers are placed automatically. Manual reordering is disabled while this is on."
+  },
   "replaceTab": {
     "message": "Replace tab instead of creating a new one"
   },


### PR DESCRIPTION
Adds three en strings for a new option in the extension that keeps the container list sorted alphabetically.

Companion to mozilla/multi-account-containers#2927, which contains the feature itself.