### PR TITLE
Fix undefined keyId placeholders in nb_NO and nn_NO

### DIFF
--- a/nb_NO/messages.json
+++ b/nb_NO/messages.json
@@ -248,7 +248,12 @@
     "message": "Rediger hvilken beholder som åpnes når du bruker de nummererte snarveiene."
   },
   "keyboardShortCut": {
-    "message": "Beholder som skal åpnes med hurtigtast $$keyId$$"
+    "message": "Beholder som skal åpnes med hurtigtast $keyId$",
+    "placeholders": {
+      "keyId": {
+        "content": "$1"
+      }
+    }
   },
   "confirmNavigationTitle": {
     "message": "Multi-Account-Container – Bekreft navigering",

--- a/nn_NO/messages.json
+++ b/nn_NO/messages.json
@@ -248,7 +248,12 @@
     "message": "Rediger kva for behaldar som vert opna når du brukar dei nummererte snarvegane."
   },
   "keyboardShortCut": {
-    "message": "Behaldar som skal opnast med hurtigtast $$keyId$$"
+    "message": "Behaldar som skal opnast med hurtigtast $keyId$",
+    "placeholders": {
+      "keyId": {
+        "content": "$1"
+      }
+    }
   },
   "confirmNavigationTitle": {
     "message": "Multi-Account-Container – Stadfest navigering",
@@ -406,8 +411,13 @@
     "description": "Label for option in the keyboard shortcut manager (associating a shortcut to open the container panel)"
   },
   "containerShortcut": {
-    "message": "Behaldarhurtigast $$keyId$$",
-    "description": "Label for option in the keyboard shortcut manager. $keyId$ is a number from 1 to 10."
+    "message": "Behaldarhurtigast $keyId$",
+    "description": "Label for option in the keyboard shortcut manager. $keyId$ is a number from 1 to 10.",
+    "placeholders": {
+      "keyId": {
+        "content": "$1"
+      }
+    }
   },
   "reopenInContainerShortcut": {
     "message": "Opne på nytt i behaldaren $keyId$",


### PR DESCRIPTION
keyboardShortCut (nb_NO, nn_NO) and containerShortcut (nn_NO) write the placeholder as $$keyId$$ and omit the placeholders block, so the UI shows the literal text $keyId$ instead of the shortcut number. This also produces addons-linter warnings on every build of the extension.

Restores the $keyId$ syntax and the placeholders definition from the en source. Translated text untouched.